### PR TITLE
AspectjExtension: property name fixed

### DIFF
--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/AspectjExtension.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/AspectjExtension.groovy
@@ -28,7 +28,7 @@ class AspectjExtension {
         return this
     }
     public AspectjExtension ajcArgs(String...ajcArgs) {
-        if (userArgs != null) {
+        if (ajcArgs != null) {
             this.ajcArgs.addAll(ajcArgs)
         }
         return this


### PR DESCRIPTION
Specifying ajcArgs param in the plugin configuration section caused and unknown property exception.