### PR TITLE
Change println usages for SLF4J logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v2.0.5(Unreleased)
+* Changed `println` usages for a SLF4J logger instance in DEBUG mode
+
 ### v2.0.4(2018-10-16)
 * [FIX] issue[#120](https://github.com/HujiangTechnology/gradle_plugin_android_aspectjx/issues/120)
 * [FIX] issue[#118](https://github.com/HujiangTechnology/gradle_plugin_android_aspectjx/issues/118)

--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/AJXPlugin.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/AJXPlugin.groovy
@@ -39,14 +39,12 @@ class AJXPlugin implements Plugin<Project> {
 
         project.dependencies {
             if (project.gradle.gradleVersion > "4.0") {
-                println "gradlew version > 4.0"
+                project.logger.debug("gradlew version > 4.0")
                 implementation 'org.aspectj:aspectjrt:1.8.9'
             } else {
-                println "gradlew version < 4.0"
+                project.logger.debug("gradlew version < 4.0")
                 compile 'org.aspectj:aspectjrt:1.8.9'
             }
-
-
         }
 
         project.extensions.create("aspectjx", AJXExtension)

--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/AJXTask.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/AJXTask.groovy
@@ -91,7 +91,7 @@ class AJXTask implements ITask {
         }
 
         inPath.each {File file ->
-            println "~~~~~~~~~~~~~input file: ${file.absolutePath}"
+            project.logger.debug("~~~~~~~~~~~~~input file: ${file.absolutePath}")
         }
 
         MessageHandler handler = new MessageHandler(true)

--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/AJXUtils.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/AJXUtils.groovy
@@ -19,6 +19,7 @@ import com.android.build.api.transform.*
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonSyntaxException
+import com.hujiang.gradle.plugin.android.aspectjx.AJXPlugin
 import com.hujiang.gradle.plugin.android.aspectjx.internal.cache.VariantCache
 import org.apache.commons.io.FileUtils
 import org.objectweb.asm.ClassReader
@@ -133,7 +134,7 @@ class AJXUtils {
      * @param transformInvocation
      */
     static void doWorkWithNoAspectj(TransformInvocation transformInvocation) {
-        LoggerFactory.getLogger('no-aspectj-logger').debug("do nothing ~~~~~~~~~~~~~~~~~~~~~~~~")
+        LoggerFactory.getLogger(AJXPlugin).debug("do nothing ~~~~~~~~~~~~~~~~~~~~~~~~")
         if (transformInvocation.incremental) {
             incrementalCopyFiles(transformInvocation)
         } else {

--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/AJXUtils.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/AJXUtils.groovy
@@ -23,6 +23,7 @@ import com.hujiang.gradle.plugin.android.aspectjx.internal.cache.VariantCache
 import org.apache.commons.io.FileUtils
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter
+import org.slf4j.LoggerFactory
 
 import java.lang.reflect.Type
 import java.util.jar.JarEntry
@@ -129,11 +130,10 @@ class AJXUtils {
     }
 
     /**
-     *
      * @param transformInvocation
      */
     static void doWorkWithNoAspectj(TransformInvocation transformInvocation) {
-        println "do nothing ~~~~~~~~~~~~~~~~~~~~~~~~"
+        LoggerFactory.getLogger('no-aspectj-logger').debug("do nothing ~~~~~~~~~~~~~~~~~~~~~~~~")
         if (transformInvocation.incremental) {
             incrementalCopyFiles(transformInvocation)
         } else {

--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/TimeTrace.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/TimeTrace.groovy
@@ -15,6 +15,7 @@
  */
 package com.hujiang.gradle.plugin.android.aspectjx.internal
 
+import com.sun.istack.internal.logging.Logger
 import org.gradle.BuildListener
 import org.gradle.BuildResult
 import org.gradle.api.Task
@@ -58,7 +59,7 @@ class TimeTrace implements TaskExecutionListener, BuildListener {
 
     @Override
     void buildFinished(BuildResult result) {
-        println "Tasks spend time > ${DISPLAY_TIME_THRESHOLD}ms:"
+        Logger.getLogger("time-logger").debug("Tasks spend time > ${DISPLAY_TIME_THRESHOLD}ms:")
 
         times.sort { lhs, rhs -> -(lhs[0] - rhs[0]) }
                 .grep { it[0] > DISPLAY_TIME_THRESHOLD }

--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/TimeTrace.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/TimeTrace.groovy
@@ -15,7 +15,7 @@
  */
 package com.hujiang.gradle.plugin.android.aspectjx.internal
 
-import com.sun.istack.internal.logging.Logger
+import com.hujiang.gradle.plugin.android.aspectjx.AJXPlugin
 import org.gradle.BuildListener
 import org.gradle.BuildResult
 import org.gradle.api.Task
@@ -23,6 +23,7 @@ import org.gradle.api.execution.TaskExecutionListener
 import org.gradle.api.initialization.Settings
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.tasks.TaskState
+import org.slf4j.LoggerFactory
 
 import java.util.concurrent.ConcurrentHashMap
 
@@ -59,7 +60,7 @@ class TimeTrace implements TaskExecutionListener, BuildListener {
 
     @Override
     void buildFinished(BuildResult result) {
-        Logger.getLogger("time-logger").debug("Tasks spend time > ${DISPLAY_TIME_THRESHOLD}ms:")
+        LoggerFactory.getLogger(AJXPlugin).debug("Tasks spend time > ${DISPLAY_TIME_THRESHOLD}ms:")
 
         times.sort { lhs, rhs -> -(lhs[0] - rhs[0]) }
                 .grep { it[0] > DISPLAY_TIME_THRESHOLD }

--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/cache/AJXCache.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/cache/AJXCache.groovy
@@ -83,7 +83,7 @@ class AJXCache {
     }
 
     void commit() {
-        println "putExtensionConfig:${extensionConfigFile}"
+        project.logger.debug("putExtensionConfig:${extensionConfigFile}")
 
         FileUtils.deleteQuietly(extensionConfigFile)
 
@@ -98,7 +98,7 @@ class AJXCache {
         }
 
         String jsonString = AJXUtils.optToJsonString(ajxExtensionConfig)
-        println "${jsonString}"
+        project.logger.debug("${jsonString}")
         FileUtils.write(extensionConfigFile, jsonString, "UTF-8")
     }
 

--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/CacheAspectFilesProcedure.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/CacheAspectFilesProcedure.groovy
@@ -41,7 +41,7 @@ class CacheAspectFilesProcedure extends AbsProcedure {
 
     @Override
     boolean doWorkContinuously() {
-        println "~~~~~~~~~~~~~~~~~~~~cache aspect files"
+        project.logger.debug("~~~~~~~~~~~~~~~~~~~~cache aspect files")
         //缓存aspect文件
         BatchTaskScheduler batchTaskScheduler = new BatchTaskScheduler()
 
@@ -53,7 +53,7 @@ class CacheAspectFilesProcedure extends AbsProcedure {
                     Object call() throws Exception {
                         dirInput.file.eachFileRecurse { File item ->
                             if (AJXUtils.isAspectClass(item)) {
-                                println "~~~~~~~~~~~~collect aspect file:${item.absolutePath}"
+                                project.logger.debug("~~~~~~~~~~~~collect aspect file:${item.absolutePath}")
                                 String path = item.absolutePath
                                 String subPath = path.substring(dirInput.file.absolutePath.length())
                                 File cacheFile = new File(variantCache.aspectPath + subPath)
@@ -80,7 +80,7 @@ class CacheAspectFilesProcedure extends AbsProcedure {
                                 byte[] bytes = ByteStreams.toByteArray(jarFile.getInputStream(jarEntry))
                                 File cacheFile = new File(variantCache.aspectPath + File.separator + entryName)
                                 if (AJXUtils.isAspectClass(bytes)) {
-                                    println "~~~~~~~~~~~collect aspect file:${entryName}"
+                                    project.logger.debug("~~~~~~~~~~~collect aspect file:${entryName}")
                                     variantCache.add(bytes, cacheFile)
                                 }
                             }

--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/CacheInputFilesProcedure.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/CacheInputFilesProcedure.groovy
@@ -43,7 +43,7 @@ class CacheInputFilesProcedure extends AbsProcedure {
         // "**" 所有class文件和jar
         // "com.hujiang" 过滤 含"com.hujiang"的文件和jar
         //
-        println "~~~~~~~~~~~~~~~~~~~~cache input files"
+        project.logger.debug("~~~~~~~~~~~~~~~~~~~~cache input files")
         BatchTaskScheduler taskScheduler = new BatchTaskScheduler()
 
         transformInvocation.inputs.each { TransformInput input ->

--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/CheckAspectJXEnableProcedure.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/CheckAspectJXEnableProcedure.groovy
@@ -33,7 +33,7 @@ class CheckAspectJXEnableProcedure extends AbsProcedure {
 
     @Override
     boolean doWorkContinuously() {
-        println "~~~~~~~~~~~~~~~~~~~~~~~ check aspectjx enable"
+        project.logger.debug("~~~~~~~~~~~~~~~~~~~~~~~ check aspectjx enable")
 
         //check if exclude all files or not
         boolean isExcludeAll = false

--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/DoAspectWorkProcedure.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/DoAspectWorkProcedure.groovy
@@ -42,7 +42,7 @@ class DoAspectWorkProcedure extends AbsProcedure {
     @Override
     boolean doWorkContinuously() {
         //do aspectj real work
-        println "~~~~~~~~~~~~~~~~~~~~do aspectj real work"
+        project.logger.debug("~~~~~~~~~~~~~~~~~~~~do aspectj real work")
         ajxTaskManager.aspectPath << variantCache.aspectDir
         ajxTaskManager.classPath << variantCache.includeFileDir
         ajxTaskManager.classPath << variantCache.excludeFileDir

--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/OnFinishedProcedure.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/OnFinishedProcedure.groovy
@@ -31,7 +31,7 @@ class OnFinishedProcedure extends AbsProcedure {
 
     @Override
     boolean doWorkContinuously() {
-        println "~~~~~~~~~~~~~~~~~~~~onFinished"
+        project.logger.debug("~~~~~~~~~~~~~~~~~~~~onFinished")
         ajxCache.commit()
 
         return true

--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/UpdateAspectFilesProcedure.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/UpdateAspectFilesProcedure.groovy
@@ -39,7 +39,7 @@ class UpdateAspectFilesProcedure extends AbsProcedure {
 
     @Override
     boolean doWorkContinuously() {
-        println "~~~~~~~~~~~~~~~~~~~~update aspect files"
+        project.logger.debug("~~~~~~~~~~~~~~~~~~~~update aspect files")
         //update aspect files
         BatchTaskScheduler taskScheduler = new BatchTaskScheduler()
 
@@ -50,7 +50,7 @@ class UpdateAspectFilesProcedure extends AbsProcedure {
                     Object call() throws Exception {
                         dirInput.changedFiles.each { File file, Status status ->
                             if (AJXUtils.isAspectClass(file)) {
-                                println "~~~~~~~~~~~collect aspect file from Dir:${file.absolutePath}"
+                                project.logger.debug("~~~~~~~~~~~collect aspect file from Dir:${file.absolutePath}")
                                 variantCache.incrementalStatus.isAspectChanged = true
                                 String path = file.absolutePath
                                 String subPath = path.substring(dirInput.file.absolutePath.length())
@@ -92,7 +92,7 @@ class UpdateAspectFilesProcedure extends AbsProcedure {
                                     byte[] bytes = ByteStreams.toByteArray(jarFile.getInputStream(jarEntry))
                                     File cacheFile = new File(variantCache.aspectPath + File.separator + entryName)
                                     if (AJXUtils.isAspectClass(bytes)) {
-                                        println "~~~~~~~~~~~~~~~~~collect aspect file from JAR:${entryName}"
+                                        project.logger.debug("~~~~~~~~~~~~~~~~~collect aspect file from JAR:${entryName}")
                                         variantCache.incrementalStatus.isAspectChanged = true
                                         if (jarInput.status == Status.REMOVED) {
                                             FileUtils.deleteQuietly(cacheFile)

--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/UpdateAspectOutputProcedure.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/UpdateAspectOutputProcedure.groovy
@@ -41,7 +41,7 @@ class UpdateAspectOutputProcedure extends AbsProcedure {
 
     @Override
     boolean doWorkContinuously() {
-        println "~~~~~~~~~~~~~~~~~~~~update aspect output"
+        project.logger.debug("~~~~~~~~~~~~~~~~~~~~update aspect output")
         ajxTaskManager.aspectPath << variantCache.aspectDir
         ajxTaskManager.classPath << variantCache.includeFileDir
         ajxTaskManager.classPath << variantCache.excludeFileDir

--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/UpdateInputFilesProcedure.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/UpdateInputFilesProcedure.groovy
@@ -36,7 +36,7 @@ class UpdateInputFilesProcedure extends AbsProcedure {
 
     @Override
     boolean doWorkContinuously() {
-        println "~~~~~~~~~~~~~~~~~~~~update input files"
+        project.logger.debug("~~~~~~~~~~~~~~~~~~~~update input files")
         BatchTaskScheduler taskScheduler = new BatchTaskScheduler()
 
         transformInvocation.inputs.each { TransformInput input ->
@@ -45,7 +45,7 @@ class UpdateInputFilesProcedure extends AbsProcedure {
                     @Override
                     Object call() throws Exception {
                         dirInput.changedFiles.each { File file, Status status ->
-                            println "~~~~~~~~~~~~~~~~changed file::${status.name()}::${file.absolutePath}"
+                            project.logger.debug("~~~~~~~~~~~~~~~~changed file::${status.name()}::${file.absolutePath}")
 
                             variantCache.includeFileContentTypes = dirInput.contentTypes
                             variantCache.includeFileScopes = dirInput.scopes
@@ -106,7 +106,7 @@ class UpdateInputFilesProcedure extends AbsProcedure {
                     taskScheduler.addTask(new ITask() {
                         @Override
                         Object call() throws Exception {
-                            println "~~~~~~~changed file::${jarInput.status.name()}::${jarInput.file.absolutePath}"
+                            project.logger.debug("~~~~~~~changed file::${jarInput.status.name()}::${jarInput.file.absolutePath}")
 
                             String filePath = jarInput.file.absolutePath
                             File outputJar = transformInvocation.outputProvider.getContentLocation(jarInput.name, jarInput.contentTypes, jarInput.scopes, Format.JAR)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 LIB_GROUP=com.hujiang.aspectjx
 LIB_ARTIFACT = gradle-android-plugin-aspectjx
-LIB_VERSION=2.0.4
+LIB_VERSION=2.0.5
 LIB_DES=A Gradle plugin which enables AspectJ for Android builds. supports Kotlin, aar, jar aspect
 LIB_ISRELEASE=true
 


### PR DESCRIPTION
Change the println usages for a SLF4J logger in debug mode always. This is just so we can have cleaner builds without too much information we won't be using on all runs. If we still wish to see the logs we can of course do `./gradlew someTask -d` for enabling debug mode