### PR TITLE
保持数据的一致性，避免出现ajcArgs出现多份

### DIFF
--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/cache/AJXCache.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/cache/AJXCache.groovy
@@ -41,7 +41,6 @@ class AJXCache {
     String bootClassPath
     String sourceCompatibility
     String targetCompatibility
-    List<String> ajcArgs = new ArrayList<>()
 
     AJXCache(Project proj) {
         this.project = proj

--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/AJXProcedure.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/AJXProcedure.groovy
@@ -64,8 +64,6 @@ class AJXProcedure extends AbsProcedure {
             }
 
             ajxCache.putExtensionConfig(ajxExtension)
-
-            ajxCache.ajcArgs = ajxExtension.ajcArgs
         }
 
         //set aspectj build log output dir

--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/DoAspectWorkProcedure.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/DoAspectWorkProcedure.groovy
@@ -35,7 +35,7 @@ class DoAspectWorkProcedure extends AbsProcedure {
 
     DoAspectWorkProcedure(Project project, VariantCache variantCache, TransformInvocation transformInvocation) {
         super(project, variantCache, transformInvocation)
-        ajxTaskManager = new AJXTaskManager(encoding: ajxCache.encoding, ajcArgs: ajxCache.ajcArgs, bootClassPath: ajxCache.bootClassPath,
+        ajxTaskManager = new AJXTaskManager(encoding: ajxCache.encoding, ajcArgs: ajxCache.ajxExtensionConfig.ajcArgs, bootClassPath: ajxCache.bootClassPath,
                 sourceCompatibility: ajxCache.sourceCompatibility, targetCompatibility: ajxCache.targetCompatibility)
     }
 

--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/UpdateAspectOutputProcedure.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/procedure/UpdateAspectOutputProcedure.groovy
@@ -35,7 +35,7 @@ class UpdateAspectOutputProcedure extends AbsProcedure {
 
     UpdateAspectOutputProcedure(Project project, VariantCache variantCache, TransformInvocation transformInvocation) {
         super(project, variantCache, transformInvocation)
-        ajxTaskManager = new AJXTaskManager(encoding: ajxCache.encoding, ajcArgs: ajxCache.ajcArgs, bootClassPath: ajxCache.bootClassPath,
+        ajxTaskManager = new AJXTaskManager(encoding: ajxCache.encoding, ajcArgs: ajxCache.ajxExtensionConfig.ajcArgs, bootClassPath: ajxCache.bootClassPath,
                             sourceCompatibility: ajxCache.sourceCompatibility, targetCompatibility: ajxCache.targetCompatibility)
     }
 


### PR DESCRIPTION
保持数据的一致性，避免出现ajcArgs出现多份