### PR TITLE
Update AJXTransform.groovy for build:gradle:4.0.0+

### DIFF
--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/AJXTransform.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/AJXTransform.groovy
@@ -65,9 +65,9 @@ class AJXTransform extends Transform {
 
         Project project = ajxProcedure.project
 
-        TransformTask transformTask = (TransformTask)transformInvocation.context
-        VariantCache variantCache = new VariantCache(ajxProcedure.project, ajxProcedure.ajxCache, transformTask.variantName)
-
+        String transformTaskVariantName = transformInvocation.context.getVariantName()
+        VariantCache variantCache = new VariantCache(ajxProcedure.project, ajxProcedure.ajxCache, transformTaskVariantName)
+        
         ajxProcedure.with(new CheckAspectJXEnableProcedure(project, variantCache, transformInvocation))
 
         if (transformInvocation.incremental) {


### PR DESCRIPTION
TransformInvocation#context has implemented by `new Context()` instead of `TransformTask.this`. If we cast it, build will fail. Use Context#getVariantName directly. (Perhaps need update api dependencies.)

```Java
        recorder.record(
                ExecutionType.TASK_TRANSFORM,
                executionInfo,
                getProject().getPath(),
                getVariantName(),
                new Recorder.Block<Void>() {
                    @Override
                    public Void call() throws Exception {
                        Context context =
                                new Context() {
                                    @NonNull
                                    @Override
                                    public String getVariantName() {
                                        return TransformTask.this.getVariantName();
                                    }
                                };
                        transform.transform(
                                new TransformInvocationBuilder(context)
                                        .addInputs(consumedInputs.getValue())
                                        .addReferencedInputs(referencedInputs.getValue())
                                        .addSecondaryInputs(changedSecondaryInputs.getValue())
                                        .addOutputProvider(
                                                outputStream != null
                                                        ? outputStream.asOutput()
                                                        : null)
                                        .setIncrementalMode(isIncremental.getValue())
                                        .build());

                        if (outputStream != null) {
                            outputStream.save();
                        }
                        return null;
                    }
                });
```