### PR TITLE
AspectJ doesn't support multi thread when using Main.run() in AJXTask…

### DIFF
--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/AJXTaskManager.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/AJXTaskManager.groovy
@@ -32,7 +32,7 @@ class AJXTaskManager {
     String sourceCompatibility
     String targetCompatibility
 
-    BatchTaskScheduler batchTaskScheduler = new BatchTaskScheduler()
+    BatchTaskScheduler batchTaskScheduler = new BatchTaskScheduler(1)
 
     AJXTaskManager() {
     }

--- a/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/concurrent/BatchTaskScheduler.groovy
+++ b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/concurrent/BatchTaskScheduler.groovy
@@ -32,6 +32,10 @@ class BatchTaskScheduler {
         executorService = Executors.newScheduledThreadPool(Runtime.runtime.availableProcessors() + 1)
     }
 
+    BatchTaskScheduler(int count) {
+        executorService = Executors.newScheduledThreadPool(count)
+    }
+
     public <T extends ITask> void addTask(T task) {
         tasks << task
     }


### PR DESCRIPTION
…. The reason is that in aspectjtools class Dump will set MessageHandler in a static field. And in latest version aspectjtools1.9.7 there is one more case, ClasspathJar also keeps openArchives in a static field and has concurrent issue.

Most of the issues about "zip is empty" is related to this bug.